### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 eth-brownie
-python-dotenv


### PR DESCRIPTION
eth-brownie already has python-dotenv of an old version as a requirement, so tryint to install both independently results in:
```
ERROR: eth-brownie 1.17.2 has requirement python-dotenv==0.16.0, but you'll have python-dotenv 0.19.2 which is incompatible.
```