### PR TITLE
Update get_weth.py

### DIFF
--- a/scripts/get_weth.py
+++ b/scripts/get_weth.py
@@ -18,6 +18,6 @@ def get_weth(account=None):
     weth = interface.WethInterface(
         config["networks"][network.show_active()]["weth_token"]
     )
-    tx = weth.deposit({"from": account, "value": 1000000000000000000})
-    print("Received 1 WETH")
+    tx = weth.deposit({"from": account, "value": 0.1 * 1e18})
+    print("Received 0.1 WETH")
     return tx


### PR DESCRIPTION
I would recommend changing the amount deposited to 0.1, since it takes 10 calls to the chainlink faucet to get 1 ETH on Kovan, which took me forever, only to realize that `aave_borrow.py` only deposits 0.1 weth on aave...! (line 5: `amount = Web3.toWei(0.1, "ether")`)